### PR TITLE
Address link for missing licenses

### DIFF
--- a/www/dashboard_project/static/html/index.html
+++ b/www/dashboard_project/static/html/index.html
@@ -312,17 +312,24 @@
             details.addClass(d['status'])
 
             license = $(div).find('.pkg-license')
-            if (d['licfile'] === '') {
+            if ( d['licfile'] === '' ) {
               license.html('<a href="' + d['url'] + '">' + d['license'] + '</a>')  
             } else {
               license.html('<a href="' + d['url'] + '/blob/master/' + d['licfile'] + '">' + d['license'] + '</a>')  
             }
             
             license.removeClass("full_pass full_fail")
-            if( d['license'] != "Unknown" )
+            if( d['license'] != "Unknown" ) {
               license.addClass("full_pass")
-            else
-              license.addClass("full_fail")
+            } else {
+              if ( d['licfile'] === '' ) {
+                // Found no license and no file
+                license.addClass("using_fail")
+              } else {
+                // License file, but empty or TBD probably
+                license.addClass("full_fail")
+              }
+            }
 
             pkgreq = $(div).find('.pkg-pkgreq')
             pkgreq.removeClass("full_pass full_fail")


### PR DESCRIPTION
Currently if license is missing the link takes you to a 404 page. Better to just take to package root.
